### PR TITLE
docs: fix github workflow badges 🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@
 
 # OKP4 Web Site
 
-[![lint](https://img.shields.io/github/workflow/status/okp4/okp4-web/Lint?label=lint&style=for-the-badge&logo=github)](https://github.com/okp4/okp4-web/actions/workflows/lint.yml)
-[![build](https://img.shields.io/github/workflow/status/okp4/okp4-web/Build?label=build&style=for-the-badge&logo=github)](https://github.com/okp4/okp4-web/actions/workflows/build.yml)
-[![test](https://img.shields.io/github/workflow/status/okp4/okp4-web/Test?label=test&style=for-the-badge&logo=github)](https://github.com/okp4/okp4-web/actions/workflows/test.yml)
+[![lint](https://img.shields.io/github/actions/workflow/status/okp4/okp4-web/lint.yml?branch=main&label=lint&style=for-the-badge&logo=github)](https://github.com/okp4/okp4-web/actions/workflows/lint.yml)
+[![build](https://img.shields.io/github/actions/workflow/status/okp4/okp4-web/build.yml?branch=main&label=build&style=for-the-badge&logo=github)](https://github.com/okp4/okp4-web/actions/workflows/build.yml)
+[![test](https://img.shields.io/github/actions/workflow/status/okp4/okp4-web/test.yml?branch=main&label=test&style=for-the-badge&logo=github)](https://github.com/okp4/okp4-web/actions/workflows/test.yml)
 [![conventional commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg?style=for-the-badge&logo=conventionalcommits)](https://conventionalcommits.org)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg?style=for-the-badge)](https://github.com/okp4/.github/blob/main/CODE_OF_CONDUCT.md)
 [![license](https://img.shields.io/github/license/okp4/okp4-web.svg?label=License&style=for-the-badge)](https://opensource.org/licenses/Apache-2.0)


### PR DESCRIPTION
This PR fixes github workflow badges after a breaking change on github platform. Everything is explained there : https://github.com/badges/shields/issues/8671

I took advantage of this PR to make the workflow status badges target only the `main` branch.

🤖 This PR is generated by this [script](https://gist.github.com/ad2ien/a335f9d405bce05ec6f6ad324afdd675#file-fix-action-status-badges-sh).
