### PR TITLE
fix(redirect): redirect sitemap and legals to okp4.network

### DIFF
--- a/okp4-gatsby/content/transversals/footer.yaml
+++ b/okp4-gatsby/content/transversals/footer.yaml
@@ -13,8 +13,8 @@ newsAndDocs:
     text: Follow the latest content and publications on the OKP4 blog.
     url: https://blog.okp4.network/
 sitemap:
-  url: /
+  url: https://okp4.network/
   text: Sitemap
 legals:
-  url: /
+  url: https://okp4.network/
   text: Legals & GDPR


### PR DESCRIPTION
Currently Sitemap and Legals sections lead to 404 error.
This PR redirects the traffic to okp4.network.