### PR TITLE
fix(url): remove okp4-web as pathPrefix

### DIFF
--- a/okp4-gatsby/gatsby-config.js
+++ b/okp4-gatsby/gatsby-config.js
@@ -8,7 +8,6 @@
  * @type {import('gatsby').GatsbyConfig}
  */
 module.exports = {
-  pathPrefix: `/okp4-web`,
   plugins: [
     `gatsby-plugin-image`,
     `gatsby-plugin-sharp`,

--- a/okp4-gatsby/package.json
+++ b/okp4-gatsby/package.json
@@ -5,7 +5,7 @@
   "version": "0.1.0",
   "license": "0BSD",
   "scripts": {
-    "build": "gatsby build --prefix-paths",
+    "build": "gatsby build",
     "develop": "gatsby develop",
     "start": "gatsby develop",
     "serve": "gatsby serve",


### PR DESCRIPTION
Because it will be hosted on OVH machine, no more need the PathPrefix.