### PR TITLE
ci(publish): deploy on OVH

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,4 +38,4 @@ jobs:
           password: ${{ secrets.OKP4_OVH_SSH_PASSWORD }}
           port: ${{ secrets.OKP4_OVH_SSH_PORT }}
           local: "okp4-gatsby/public"
-          remote: "/homez.216/okpcomnvui/okp4-web"
+          remote: ${{ secrets.OKP4_OVH_SSH_PATH }}


### PR DESCRIPTION
As the okp4-web is now deployed on the OVH machine, we had to automate it.
This workflow copies the build files to the remote machine via SSH (scp like action).