### PR TITLE
ci(publish): prepare a staging environment

### DIFF
--- a/.github/workflows/publish-prod.yml
+++ b/.github/workflows/publish-prod.yml
@@ -1,4 +1,4 @@
-name: Publish
+name: Publish production
 
 on:
   workflow_dispatch:

--- a/.github/workflows/publish-staging.yml
+++ b/.github/workflows/publish-staging.yml
@@ -1,0 +1,42 @@
+name: Publish staging
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: publish-staging-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  publish-gh-pages:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Setup node environment (for building)
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.13.0
+
+      - name: Fetch dependencies
+        working-directory: okp4-gatsby
+        run: |
+          yarn --frozen-lockfile
+
+      - name: Build
+        working-directory: okp4-gatsby
+        run: |
+          yarn build
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.OKP4_TOKEN }}
+          publish_dir: okp4-gatsby/public
+          commit-message: |
+            chore: deploy okp4-web github pages ${{ steps.get_version.outputs.version }} on staging
+          cname: staging.okp4.network


### PR DESCRIPTION
As requested by Joey, here is the setup for a staging environment.
Because the prod is hosted on OVH, we can use this gh-page to host the staging env.
In the future, to host both environments on gh-page, we could use a mirror repository to host the other environment (only one site can be host by repo on gh-page).