### PR TITLE
ci(publish): change prod trigger on tags

### DIFF
--- a/.github/workflows/publish-prod.yml
+++ b/.github/workflows/publish-prod.yml
@@ -3,6 +3,10 @@ name: Publish production
 on:
   workflow_dispatch:
 
+  push:
+    tags:
+      - "v*"
+
 concurrency:
   group: publish-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Self explanatory.

I set the v1.0.0 tag on currently deployed commit.
https://github.com/okp4/okp4-web/releases/tag/v1.0.0