### PR TITLE
feat: remove mention to web agency from the footer

### DIFF
--- a/okp4-gatsby/src/components/Footer.js
+++ b/okp4-gatsby/src/components/Footer.js
@@ -207,14 +207,6 @@ const Footer = ({ files, withDocsAndPartners = false }) => {
               >
                 {contentFooter.legals.text}
               </Link>
-              <a
-                href="https://w2p-digital.com/"
-                className="footer__main__sitemap__item footer__main__sitemap__item--w2p"
-                target="_blank"
-                rel="noreferrer"
-              >
-                Made by W2P Digital
-              </a>
             </div>
           </div>
         </div>


### PR DESCRIPTION
This PR aims to remove the mention of the `W2P Digital` web agency on the footer of our website - unless there is a contractual obligation to do so. I want to emphasize that our website's developments are meant to be licensed under an open license, and the product itself is a common good that results from the collective efforts of various individuals.

<img width="392" alt="image" src="https://user-images.githubusercontent.com/9574336/220731184-39831949-dab7-40c7-b870-82c8ca901f6a.png">
