### PR TITLE
fix(utils): handle runtime error in mediamanager

### DIFF
--- a/okp4-gatsby/src/utils/MediaManager.js
+++ b/okp4-gatsby/src/utils/MediaManager.js
@@ -1,6 +1,6 @@
 export function GetImage(filename, allFiles) {
   let imageData;
-  const image = allFiles.allImages.edges.find((file) => {
+  const image = allFiles?.allImages.edges.find((file) => {
     return file.node.relativePath === filename;
   });
 
@@ -15,7 +15,7 @@ export function GetImage(filename, allFiles) {
 
 export function GetVideo(filename, allFiles) {
   let videoData;
-  const video = allFiles.allVideos.edges.find((file) => {
+  const video = allFiles?.allVideos.edges.find((file) => {
     return file.node.relativePath === filename;
   });
 


### PR DESCRIPTION
With Gatsby data is accessed through the data layer. We're using pageQuery to do this and it could happen that allFiles does not have allImages and allVideos as properties when called in with the GetImage/GetVideo function.

![Capture d’écran 2023-02-23 à 15 32 46](https://user-images.githubusercontent.com/35332974/221164086-f5cfa777-1e84-400b-a7e2-b40c3e5d86c6.png)

