### PR TITLE
fix(dataverse): fix styles & mobile version

### DIFF
--- a/okp4-gatsby/src/assets/styles/pages/learn/_dataverse.scss
+++ b/okp4-gatsby/src/assets/styles/pages/learn/_dataverse.scss
@@ -521,11 +521,14 @@ main.dataverse {
       max-width: 400px;
       height: 447px;
       padding: 10px 50px;
-      background: linear-gradient(222.68deg, #f9f9f9 13.75%, #d9e3ff 76.51%);
       border: 1px solid #ffffff;
       border-radius: 20px;
       color: $textblue;
       line-height: 33px;
+      background: url("/images/grain.png"),
+        linear-gradient(222.68deg, #f9f9f9 13.75%, #d3defa 76.51%);
+      background-repeat: repeat;
+      background-size: contain;
 
       @include media-bp-down(lg) {
         width: 100%;


### PR DESCRIPTION
This PR fixes : 

- the horizontal scroll in mobile version due to the wrong placement of the halo
- in the "IBC" part we can't select text on mobile
- the first title was displayed in 3 lines on Firefox
