### PR TITLE
feat(hp): add dataverse cta button on a hp

### DIFF
--- a/okp4-gatsby/content/pages/index/universe.yaml
+++ b/okp4-gatsby/content/pages/index/universe.yaml
@@ -28,3 +28,4 @@ items:
     tag: OKP4
     image: index_universe_dg.png
     button: Discover
+    link: /explore/dataverse-gateways


### PR DESCRIPTION
This PR adds a Dataverse Gateways CTA button on a homepage. Since the page is not deployed yet the button takes us to the 404 page, but should be fine after the page is live. 

![image](https://user-images.githubusercontent.com/83208740/222382214-ac0105f3-799a-477d-9654-c3ea5f02a3e6.png)
