### PR TITLE
Fix: remove external links on mobile submenu open

### DIFF
--- a/okp4-gatsby/src/assets/styles/transversals/_header.scss
+++ b/okp4-gatsby/src/assets/styles/transversals/_header.scss
@@ -234,6 +234,7 @@ header.header {
             flex-direction: column;
             row-gap: 30px;
             margin: unset;
+            margin-bottom: 30px;
           }
           .header__menu__item {
             display: inline-block;

--- a/okp4-gatsby/src/components/Header.js
+++ b/okp4-gatsby/src/components/Header.js
@@ -17,10 +17,15 @@ import contentSocials from "/content/transversals/socials.yaml";
 import contentHeader from "/content/transversals/header.yaml";
 import Menu from "./Menu";
 import Breadcrumbs from "./Breadcrumbs";
+import { useBreakpoint } from "../hook/useBreakpoint";
 
 const Header = ({ isPositionFixed = false, breadcrumbs }) => {
+  const { isLarge } = useBreakpoint();
+  const [isSubMenuOpen, setIsSubMenuOpen] = useState(false);
   const divRef = useRef(null);
   const divMobile = useRef(null);
+
+  const showSocials = isLarge || !isSubMenuOpen;
 
   const getRatio = useCallback(() => {
     const windowHeight =
@@ -67,6 +72,10 @@ const Header = ({ isPositionFixed = false, breadcrumbs }) => {
     if (event.keyCode === 13) toggleBurger();
   };
 
+  const handleMenuItemClick = (hasSubMenu) => {
+    setIsSubMenuOpen(hasSubMenu);
+  };
+
   useEffect(() => {
     setTimeout(function () {
       window.addEventListener("scroll", scrollStarted);
@@ -102,70 +111,72 @@ const Header = ({ isPositionFixed = false, breadcrumbs }) => {
         </div>
       </div>
       <div className="wrapper header--desktop">
-        <div className="header__top">
-          <div className="header__top__message">
-            <p
-              dangerouslySetInnerHTML={{
-                __html: contentHeader.messageSocial,
-              }}
-            ></p>
+        {showSocials && (
+          <div className="header__top">
+            <div className="header__top__message">
+              <p
+                dangerouslySetInnerHTML={{
+                  __html: contentHeader.messageSocial,
+                }}
+              ></p>
+            </div>
+            <div className="header__socials">
+              <a
+                href={contentSocials.linkedin.url}
+                className="header__socials__link"
+                target="_blank"
+                rel="noreferrer"
+              >
+                <IconLinkedin />
+              </a>
+              <a
+                href={contentSocials.twitter.url}
+                className="header__socials__link"
+                target="_blank"
+                rel="noreferrer"
+              >
+                <IconTwitter />
+              </a>
+              <a
+                href={contentSocials.github.url}
+                className="header__socials__link"
+                target="_blank"
+                rel="noreferrer"
+              >
+                <IconGithub />
+              </a>
+              <a
+                href={contentSocials.medium.url}
+                className="header__socials__link"
+                target="_blank"
+                rel="noreferrer"
+              >
+                <IconMedium />
+              </a>
+              <a
+                href={contentSocials.discord.url}
+                className="header__socials__link"
+                target="_blank"
+                rel="noreferrer"
+              >
+                <IconDiscord />
+              </a>
+              <a
+                href={contentSocials.telegram.url}
+                className="header__socials__link"
+                target="_blank"
+                rel="noreferrer"
+              >
+                <IconTelegram />
+              </a>
+            </div>
           </div>
-          <div className="header__socials">
-            <a
-              href={contentSocials.linkedin.url}
-              className="header__socials__link"
-              target="_blank"
-              rel="noreferrer"
-            >
-              <IconLinkedin />
-            </a>
-            <a
-              href={contentSocials.twitter.url}
-              className="header__socials__link"
-              target="_blank"
-              rel="noreferrer"
-            >
-              <IconTwitter />
-            </a>
-            <a
-              href={contentSocials.github.url}
-              className="header__socials__link"
-              target="_blank"
-              rel="noreferrer"
-            >
-              <IconGithub />
-            </a>
-            <a
-              href={contentSocials.medium.url}
-              className="header__socials__link"
-              target="_blank"
-              rel="noreferrer"
-            >
-              <IconMedium />
-            </a>
-            <a
-              href={contentSocials.discord.url}
-              className="header__socials__link"
-              target="_blank"
-              rel="noreferrer"
-            >
-              <IconDiscord />
-            </a>
-            <a
-              href={contentSocials.telegram.url}
-              className="header__socials__link"
-              target="_blank"
-              rel="noreferrer"
-            >
-              <IconTelegram />
-            </a>
-          </div>
-        </div>
+        )}
         <div className="header__bottom">
           <Link to="/" className="header__logo">
             <IconLogo />
           </Link>
-          <Menu />
+          <Menu handleMenuItemClick={handleMenuItemClick} />
           <nav className="header__resources">
             <a
               href={contentSocials.pollen.url}

--- a/okp4-gatsby/src/components/Menu.js
+++ b/okp4-gatsby/src/components/Menu.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useCallback, useState, useRef } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import { Link } from "gatsby";
 import menu from "/content/transversals/menu.yaml";
 import classNames from "classnames";
@@ -36,7 +36,7 @@ const SubMenu = ({ subMenu }) => (
   </div>
 );
 
-const Menu = () => {
+const Menu = ({ handleMenuItemClick }) => {
   const { isLarge } = useBreakpoint();
   const location = useLocation();
   const [selectedMenu, setSelectedMenu] = useState(null);
@@ -66,6 +66,10 @@ const Menu = () => {
     },
     [selectedMenu]
   );
+
+  useEffect(() => {
+    handleMenuItemClick(!!selectedMenu?.subMenuItems?.length);
+  }, [handleMenuItemClick, selectedMenu]);
 
   const isActiveMenu = useCallback(
     (menuItem) =>


### PR DESCRIPTION
This PR is to remove external links like "pollen", "whitepaper" & "nemeton" when we are in mobile screen because it adds too much information to the navigation screen (they remain available in the footer).
Also, the links to social networks disappear when opening a sub-menu in order to focus the user's attention on the sub-menu information only.