### PR TITLE
fix: make logo visible in footer

### DIFF
--- a/okp4-gatsby/src/assets/styles/transversals/_header.scss
+++ b/okp4-gatsby/src/assets/styles/transversals/_header.scss
@@ -19,7 +19,6 @@ header.header {
   &.is-reset {
     opacity: 0;
     pointer-events: none;
-    visibility: hidden;
   }
 
   &.burger-opened {

--- a/okp4-gatsby/src/components/Header.js
+++ b/okp4-gatsby/src/components/Header.js
@@ -77,8 +77,8 @@ const Header = ({ isPositionFixed = false, breadcrumbs }) => {
   };
 
   useEffect(() => {
-    window.addEventListener("scroll", scrollStarted);
     setTimeout(function () {
+      window.addEventListener("scroll", scrollStarted);
       ResponsiveManager.initViewportHeightForMobile();
     }, 1000);
 


### PR DESCRIPTION
The footer okp4 logo was invisible in some pages, it is always visible now.
The regression was brought by this [PR](https://github.com/okp4/okp4-web/pull/95)