### PR TITLE
fix: halo size & keywords wrap

### DIFF
--- a/okp4-gatsby/src/assets/styles/pages/explore/_dataverseGateways.scss
+++ b/okp4-gatsby/src/assets/styles/pages/explore/_dataverseGateways.scss
@@ -175,7 +175,7 @@ main.dataverseGateways {
           padding: 20px 25px 25px;
           @include media-bp-down(lg) {
             max-width: 354px;
-            height: 351px;
+            height: 367px;
             width: auto;
           }
           border-radius: 20px;


### PR DESCRIPTION
This PR fixes the halo which was not round enough & keywords wrapping on mobile size.