### PR TITLE
fix: replace url link by word link

### DIFF
--- a/okp4-gatsby/content/pages/develop/developmentKit.yaml
+++ b/okp4-gatsby/content/pages/develop/developmentKit.yaml
@@ -33,6 +33,6 @@ protocol:
 documentation:
   header: deep documentation
   description:
-    - All the technical documentation related to the blockchain and its modules dedicated to developers and validators is available here&colon; <a href="https://docs.okp4.network" rel="noreferrer" target="_blank">https://docs.okp4.network</a>
+    - All the technical documentation related to the blockchain and its modules dedicated to developers and validators is available <a href="https://docs.okp4.network" rel="noreferrer" target="_blank">here</a>.
     - "It includes API documentation to interact with smart contracts & modules: define any custom rule, connect any service..."
     - You can find all the resources on the <a href="https://github.com/okp4/awesome" rel="noreferrer" target="_blank">Awesome OKP4</a>, a curated list of awesome resources, documents, and tools for OKP4.

--- a/okp4-gatsby/src/assets/styles/pages/develop/_developmentkit.scss
+++ b/okp4-gatsby/src/assets/styles/pages/develop/_developmentkit.scss
@@ -376,16 +376,15 @@
 
       .developmentkit__description {
         max-width: 724px;
-      }
-
-      p {
-        @include media-bp-down(lg) {
-          font-size: 20px;
+        p {
+          @include media-bp-down(lg) {
+            font-size: 20px;
+          }
         }
-      }
 
-      p:last-of-type > a {
-        border-bottom: 1px solid #ffffff;
+        p > a {
+          border-bottom: 1px solid #ffffff;
+        }
       }
     }
   }


### PR DESCRIPTION
This pr replaces the url link: "... validators is available here : https://docs.okp4.network" by "... validators is available **here**."