### PR TITLE
fix: hide header on scrolled homepage

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -44,14 +44,15 @@ const Header = ({ isPositionFixed = false, breadcrumbs }) => {
     if (divRef.current) {
       if (window.scrollY < windowHeight + 100) {
         divRef.current.classList.remove("is-reset");
-        let ratio = getRatio();
 
+        const ratio = getRatio();
         if (ResponsiveManager.isWindowLarger("lg")) {
           divRef.current.style.opacity = ratio;
         } else if (divMobile.current) {
           divMobile.current.style.opacity = ratio;
         }
       } else {
+        divRef.current.style.opacity = null;
         divRef.current.classList.add("is-reset");
       }
     }


### PR DESCRIPTION
This PR fixes the bug on the header.
When we scroll the homepage, if we refresh the page, the header is visible and disappears when we scroll again.
Now when we refresh, the header is not visible.