### PR TITLE
fix: add timeout to scroll to top on refresh

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,4 +1,5 @@
 exports.shouldUpdateScroll = () => {
-  window.scrollTo(0, 0);
+  // timeout added to give the application time to set the window before scrolling
+  setTimeout(() => window.scrollTo(0, 0), 100);
   return false;
 };


### PR DESCRIPTION
This PR adds a `setTimeout` to fix the "scroll to top on refresh" issue.

I think we can create an issue in order to remove all the `setTimeout` in the application.
I tried to do it into this PR, but I encountered some errors. It's safer to do it in a dedicated PR. (FYI @ccamel )