### PR TITLE
fix(homepage): reorder universe part items

### DIFF
--- a/src/components/pages/index/Universe.js
+++ b/src/components/pages/index/Universe.js
@@ -63,7 +63,7 @@ const Universe = ({ files }) => {
             <div className="universe__sticky">
               <h2 className="universe__title">{contentUniverse.title}</h2>
               <div className="universe__illus">
-                {contentUniverse.items.reverse().map((item, index) => {
+                {contentUniverse.items.map((item, index) => {
                   let isActive = "";
                   if (index === 0) isActive = " is-active";
                   return (


### PR DESCRIPTION
This PR fixes the wrong order of the items in the Universe part of the Homepage.

Before : 
![Capture d’écran 2023-03-23 à 13 56 46](https://user-images.githubusercontent.com/107192362/227211543-bc4ec0e0-7b2d-4d49-9d64-ab511b1ef8d5.png)

After : 
![image](https://user-images.githubusercontent.com/107192362/227211626-f5b94b86-8620-4e04-ac4f-531e0ea25900.png)
