### PR TITLE
feat: redirect http to https

### DIFF
--- a/.github/environments/prod/.htaccess
+++ b/.github/environments/prod/.htaccess
@@ -1,5 +1,5 @@
 RewriteEngine On
-RewriteCond %{HTTPS} !on
+RewriteCond %{SERVER_PORT} 80
 RewriteRule ^(.*)$ https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
 
 <Files "env.js">


### PR DESCRIPTION
This PR is about redirecting http://okp4.network/ automatically to https://okp4.network/.

It adds rules to `.htaccess` file.
The Rewrite rule is `RewriteRule ^(.*)$ https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]`
- The `R` flag means "redirect" and tells the browser to redirect. The `301` code is the HTTP code that means "Moved Permanently" : a permanent redirect.
- The `L` flag means "last" and is used to stop processing, no further rules will be processed. It almost always used when the `R`flag is used.

I don't know if this will work, but from what I understand, this is the way we can automatically redirect http to https with `.htaccess`.

I hope `%{HTTP_HOST}` contains the value we want, otherwise we will replace it by `okp4.network` directly.
